### PR TITLE
Fix directory path in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Reads directly from the system Launchpad database:
 1. **Clone the repository**
    ```bash
    git clone https://github.com/yourusername/LaunchNext.git
-   cd LaunchNext/LaunchNext
+   cd LaunchNext
    ```
 
 2. **Open in Xcode**


### PR DESCRIPTION
Because the file in .xcodeproj exists in the parent folder, it can cause confusion to the user who wants to build the project after first encountering it, so change the path of cd nextLaunch/nextLaunch to cd nextLaunch