### PR TITLE
feat: Add F4 hotkey and fix window focus issue

### DIFF
--- a/LaunchNext/AppStore.swift
+++ b/LaunchNext/AppStore.swift
@@ -736,7 +736,7 @@ final class AppStore: ObservableObject {
         return UserDefaults.standard.bool(forKey: rememberPageKey)
     }
 
-    @Published var globalHotKey: HotKeyConfiguration? = AppStore.loadHotKeyConfiguration() {
+    @Published var globalHotKey: HotKeyConfiguration? = AppStore.loadHotKeyConfiguration() ?? HotKeyConfiguration(keyCode: 118, modifierFlags: []) {
         didSet {
             persistHotKeyConfiguration()
             AppDelegate.shared?.updateGlobalHotKey(configuration: globalHotKey)

--- a/LaunchNext/LaunchpadApp.swift
+++ b/LaunchNext/LaunchpadApp.swift
@@ -300,6 +300,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSGestureR
         window.makeKeyAndOrderFront(nil)
         window.collectionBehavior = [.transient, .canJoinAllApplications, .fullScreenAuxiliary, .ignoresCycle]
         window.orderFrontRegardless()
+        
+        // Force window to become key and main window for proper focus
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKey()
+        window.makeMain()
 
         lastShowAt = Date()
         windowIsVisible = true
@@ -308,6 +313,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSGestureR
 
         animateWindow(to: 1) {
             self.windowIsVisible = true
+            // Ensure focus after animation completes
+            DispatchQueue.main.async {
+                self.window?.makeKey()
+                self.window?.makeMain()
+            }
         }
     }
 


### PR DESCRIPTION
- Set F4 as default global hotkey for LaunchNext
- Fix window focus issue when opening with hotkey
- Add proper window activation and focus management
- Ensure keyboard input works immediately after opening

Changes:
- AppStore.swift: Set F4 (keyCode: 118) as default hotkey
- LaunchpadApp.swift: Add NSApp.activate() and window.makeKey()/makeMain()
- Add focus restoration after animation completes

Fixes: Window not receiving focus when opened via hotkey, requiring mouse click to type in search